### PR TITLE
removed deprecated rubocop rules to placate my linter

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -42,12 +42,6 @@ Style/FrozenStringLiteralComment:
   Description: This cop is designed to help upgrade to Ruby 3.0
   Enabled: false
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
 Style/InlineComment:
   Description: Avoid inline comments.
   Enabled: false
-
-Style/WhileUntilModifier:
-  MaxLineLength: 100


### PR DESCRIPTION
Rubocop was giving me errors for v 0.52.1 . a couple of the rules have been deprecated.  