### PR TITLE
Fix config to work with latest release of rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    itrg_rubocop_config (1.0.2)
+    itrg_rubocop_config (1.0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -14,4 +14,4 @@ DEPENDENCIES
   itrg_rubocop_config!
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ gem 'itrg_rubocop_config', '1.0.1'
 
 # Ruby 2.5
 gem 'itrg_rubocop_config', '1.0.2'
+
 ```
 
 Add Rubocop, if for some reason it isn't there:
@@ -23,6 +24,10 @@ gem 'rubocop', '~> 0.51.0'
 
 # Ruby 2.5
 gem 'rubocop', '~> 0.52.1'
+
+# Rubocop 0.79
+gem 'rubocop', '~> 0.79'
+gem 'itrg_rubocop_config', '1.0.3'
 ```
 
 Modify your ```.rubocop.yml```, remove all your app specific settings and add the following:

--- a/lib/itrg_rubocop_config/version.rb
+++ b/lib/itrg_rubocop_config/version.rb
@@ -1,3 +1,3 @@
 module ItrgRubocopConfig
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,4 +1,4 @@
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Layout/MultilineOperationIndentation:
@@ -13,7 +13,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   AllowURI: true
   Max: 120
   URISchemes:


### PR DESCRIPTION
Rubocop updated and a couple of the configs moved. This fixes the yml to match the new pathing.